### PR TITLE
fix(server): QBCore export

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -22,4 +22,3 @@ server_scripts {
 }
 
 client_script "cl_mdt.lua"
-shared_script '@qb-core/import.lua'

--- a/sv_mdt.lua
+++ b/sv_mdt.lua
@@ -1,3 +1,4 @@
+local QBCore = exports['qb-core']:GetCoreObject()
 local call_index = 0
 
 RegisterServerEvent("mdt:hotKeyOpen")


### PR DESCRIPTION
Client doesn't have any QBCore calls so it doesn't need to export